### PR TITLE
Updated build.py to allow parameter passing

### DIFF
--- a/build-env.py
+++ b/build-env.py
@@ -146,7 +146,7 @@ def getLINKFLAGS(mode, LINK):
   return result
 
 
-def Environment():
+def Environment(*args, **keywords):
   # allow the user discretion to choose the MSVC version
   vars = Variables()
   if os.name == 'nt':
@@ -170,7 +170,7 @@ def Environment():
   vars.Add(BoolVariable('Werror', 'Treat warnings as errors', 0))
 
   # create an Environment
-  env = OldEnvironment(tools = getTools(), variables = vars)
+  env = OldEnvironment(*args, tools = getTools(), variables = vars, **keywords)
 
   # get the absolute path to the directory containing
   # this source file


### PR DESCRIPTION
This makes it possible to pass parameters to the Environment() call to specify options like CC and CXX
