### PR TITLE
Default 'arch' and fix environment variable copy

### DIFF
--- a/build-env.py
+++ b/build-env.py
@@ -213,10 +213,9 @@ def Environment(*args, **keywords):
   # on shared libraries
   # XXX we should probably just copy the entire environment
   if os.name == 'posix':
-    if env['PLATFORM'] == "darwin":
-      env['ENV']['DYLD_LIBRARY_PATH'] = os.environ['DYLD_LIBRARY_PATH']
-    else:
-      env['ENV']['LD_LIBRARY_PATH'] = os.environ['LD_LIBRARY_PATH']
+    for k in os.environ:
+        if k in ('DYLD_LIBRARY_PATH', 'LD_LIBRARY_PATH') or k.startswith('NV') or k.startswith('CUDA'):
+            env['ENV'][k] = os.environ[k]
 
   # generate help text
   Help(vars.GenerateHelpText(env))

--- a/build-env.py
+++ b/build-env.py
@@ -157,8 +157,8 @@ def Environment(*args, **keywords):
                         allowed_values = ('release', 'debug')))
 
   # add a variable to handle compute capability
-  vars.Add(EnumVariable('arch', 'Compute capability code generation', 'sm_10',
-                        allowed_values = ('sm_10', 'sm_11', 'sm_12', 'sm_13', 'sm_20', 'sm_21', 'sm_30')))
+  vars.Add(EnumVariable('arch', 'Compute capability code generation', None,
+                        allowed_values = ('sm_10', 'sm_11', 'sm_12', 'sm_13', 'sm_20', 'sm_21', 'sm_30','sm_32','sm_35','sm_37','sm_50','sm_52','sm_53')))
 
   # add a variable to handle warnings
   if os.name == 'posix':
@@ -187,7 +187,8 @@ def Environment(*args, **keywords):
   env.Append(CXXFLAGS = getCXXFLAGS(env['mode'], env['Wall'], env['Werror'], env.subst('$CXX')))
 
   # get NVCC compiler switches
-  env.Append(NVCCFLAGS = getNVCCFLAGS(env['mode'], env['arch']))
+  if 'arch' in env:
+      env.Append(NVCCFLAGS = getNVCCFLAGS(env['mode'], env['arch']))
 
   # get linker switches
   env.Append(LINKFLAGS = getLINKFLAGS(env['mode'], env.subst('$LINK')))


### PR DESCRIPTION
The first commit removes the default 'arch' and just lets nvcc pick. This was useful for me since my platform doesn't even support 'sm_10'. I also added the new allowed.

The second commit:
- Copies anything in the environment starting with NV or CUDA
- Fixes a crash when LD_LIBRARY_PATH wasn't set
